### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Also confirmed to work with these other styli:
 The tool will definitely break when the reMarkable updates. When that happens, just reinstall!
 # Install Instructions
 ```shell
-cd; wget https://github.com/isaacwisdom/RemarkableLamyEraser/raw/v1/LamyInstall.sh; chmod +x LamyInstall.sh; ./LamyInstall.sh; rm ~/LamyInstall.sh;
+cd; wget https://github.com/isaacwisdom/RemarkableLamyEraser/raw/v1/LamyInstall.sh; sh ./LamyInstall.sh; rm ~/LamyInstall.sh;
 ```
 # Uninstall Instrucions
 ```shell
-cd; wget https://github.com/isaacwisdom/RemarkableLamyEraser/raw/v1/LamyUninstall.sh; chmod +x LamyUninstall.sh; ./LamyUninstall.sh; rm ~/LamyUninstall.sh;
+cd; wget https://github.com/isaacwisdom/RemarkableLamyEraser/raw/v1/LamyUninstall.sh; sh ./LamyUninstall.sh; rm ~/LamyUninstall.sh;
 ```
 
 


### PR DESCRIPTION
removed superfluous "chmod +x"

"chmod +x" is not really neccessary for this one-liner. The installer can be run just by using it as parameter to "sh"