### PR TITLE
Check for current software release instead of previous version

### DIFF
--- a/sources/orientation.c
+++ b/sources/orientation.c
@@ -131,11 +131,11 @@ int getRmVersion() {
 
 int getSoftwareVersion (int softwareVersionArray[4]) {
   //returns -1 if failed to get software versions, 1 on success.
-  const char *sysPath = "/home/root/.config/remarkable/xochitl.conf";
+  const char *sysPath = "/usr/share/remarkable/update.conf";
   char softwareVersion[15];
   char *token;
 
-  if ( getConf(sysPath, "PreviousVersion=", softwareVersion, sizeof(softwareVersion)) == -1)
+  if ( getConf(sysPath, "REMARKABLE_RELEASE_VERSION=", softwareVersion, sizeof(softwareVersion)) == -1)
       return -1;
   //printf("string from conf file: %s\n", softwareVersion),
 


### PR DESCRIPTION
I just found an `update.conf` file located in `/usr/share/remarkable` that holds the current software version of the remarkable.

To use this information instead of the `previousVersion` in `/home/root/.config/remarkable/xochitl.conf` would solve my installation issue that I filed in #66 .

Please be aware that I could not try the modifications that I made since I was not able to setup the entire toolchain for cross compilation but I guess the change is quite straight forward.

Could you please merge and test this and release a new executable?